### PR TITLE
Port to EF Core

### DIFF
--- a/EdmObjectsGenerator/DbContextGenerator.cs
+++ b/EdmObjectsGenerator/DbContextGenerator.cs
@@ -2,19 +2,17 @@
 {
     using System;
     using System.Collections.Generic;
-   // using Microsoft.EntityFrameworkCore;
     using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
     using System.Text.RegularExpressions;
-    using System.Threading;
     using System.Xml;
+    using System.ComponentModel.DataAnnotations.Schema;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Edm.Csdl;
     using Microsoft.OData.Edm.Validation;
-    using System.Data.Entity;
-    using System.ComponentModel.DataAnnotations.Schema;
 
     [Serializable]
     public class DbContextGenerator
@@ -126,8 +124,9 @@
             //generate the DbContext type
             var entitiesBuilder = moduleBuilder.DefineType(dbContextName, TypeAttributes.Class | TypeAttributes.Public, typeof(DbContext));
             var dbContextType = typeof(DbContext);
-            entitiesBuilder.CreateDefaultConstructor(dbContextType, $"name={dbContextName}");
-            entitiesBuilder.CreateConnectionStringConstructor(dbContextType);
+            //entitiesBuilder.CreateDefaultConstructor(dbContextType, $"name={dbContextName}");
+            //entitiesBuilder.CreateConnectionStringConstructor(dbContextType);
+            entitiesBuilder.CreateContextOptionsConstructor(dbContextType);
 
             foreach (var entitySet in model.EntityContainer.EntitySets())
             {
@@ -140,17 +139,17 @@
                 }
             }
 
-            // create the OnModelCreating method
-            MethodBuilder methodbuilder = entitiesBuilder.DefineMethod("OnModelCreating", MethodAttributes.Public
-                                                                                          | MethodAttributes.HideBySig
-                                                                                          | MethodAttributes.CheckAccessOnOverride
-                                                                                          | MethodAttributes.Virtual,
-                                                                                          typeof(void), new Type[] { typeof(DbModelBuilder) });
+//            // create the OnModelCreating method
+//            MethodBuilder methodbuilder = entitiesBuilder.DefineMethod("OnModelCreating", MethodAttributes.Public
+//                                                                                          | MethodAttributes.HideBySig
+//                                                                                          | MethodAttributes.CheckAccessOnOverride
+//                                                                                          | MethodAttributes.Virtual,
+//                                                                                          typeof(void), new Type[] { typeof(DbModelBuilder) });
 
-            // generate the IL for the OnModelCreating method
-            ILGenerator ilGenerator = methodbuilder.GetILGenerator();
-//todo: insert code
-            ilGenerator.Emit(OpCodes.Ret);
+//            // generate the IL for the OnModelCreating method
+//            ILGenerator ilGenerator = methodbuilder.GetILGenerator();
+////todo: insert code
+//            ilGenerator.Emit(OpCodes.Ret);
             entitiesBuilder.CreateType();
         }
 

--- a/EdmObjectsGenerator/DbContextGenerator.cs
+++ b/EdmObjectsGenerator/DbContextGenerator.cs
@@ -14,6 +14,7 @@
     using Microsoft.OData.Edm.Csdl;
     using Microsoft.OData.Edm.Validation;
     using System.Data.Entity;
+    using System.ComponentModel.DataAnnotations.Schema;
 
     [Serializable]
     public class DbContextGenerator
@@ -169,6 +170,13 @@
                 }
 
                 var typeBuilder = moduleBuilder.DefineType(moduleName, TypeAttributes.Class | TypeAttributes.Public, previouslyBuiltType);
+                // Add [ComplexType] attribute to complex types
+                if (targetType.TypeKind == EdmTypeKind.Complex)
+                {
+                    var complexAttrBuilder = new CustomAttributeBuilder(typeof(ComplexTypeAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>());
+                    typeBuilder.SetCustomAttribute(complexAttrBuilder);
+                }
+
                 var typeBuilderInfo = new TypeBuilderInfo() {Builder = typeBuilder.GetTypeInfo(), IsDerived = true};
                 _typeBuildersDict.Add(moduleName, typeBuilderInfo);
                 _builderQueue.Enqueue(typeBuilderInfo);
@@ -178,6 +186,13 @@
             else
             {
                 var typeBuilder = moduleBuilder.DefineType(moduleName, TypeAttributes.Class | TypeAttributes.Public);
+                // Add [ComplexType] attribute to complex types
+                if (targetType.TypeKind == EdmTypeKind.Complex)
+                {
+                    var complexAttrBuilder = new CustomAttributeBuilder(typeof(ComplexTypeAttribute).GetConstructor(Type.EmptyTypes), Array.Empty<object>());
+                    typeBuilder.SetCustomAttribute(complexAttrBuilder);
+                }
+
                 var builderInfo = new TypeBuilderInfo() {Builder = typeBuilder.GetTypeInfo(), IsDerived = false};
                 _typeBuildersDict.Add(moduleName, builderInfo);
                 _builderQueue.Enqueue(builderInfo);

--- a/EdmObjectsGenerator/TypeBuilderHelpers.cs
+++ b/EdmObjectsGenerator/TypeBuilderHelpers.cs
@@ -101,6 +101,24 @@
             emitter.Emit(OpCodes.Ret);
         }
 
+        public static void CreateContextOptionsConstructor(this TypeBuilder builder, Type baseType)
+        {
+            var optionsType = typeof(DbContextOptions);
+            var baseCtor = baseType.GetConstructor(new Type[] { optionsType });
+
+            var ctor = builder.DefineConstructor(MethodAttributes.Public, baseCtor.CallingConvention, new Type[] { optionsType });
+
+            var emitter = ctor.GetILGenerator();
+            emitter.Emit(OpCodes.Nop);
+
+            // Load `this` and call base constructor with DbContextOptions arg passed to this constructor
+            emitter.Emit(OpCodes.Ldarg_0);
+            emitter.Emit(OpCodes.Ldarg_1);
+            emitter.Emit(OpCodes.Call, baseCtor);
+
+            emitter.Emit(OpCodes.Ret);
+        }
+
         private static CustomAttributeBuilder[] BuildCustomAttributes(IEnumerable<CustomAttributeData> customAttributes)
         {
             return customAttributes.Select(attribute => {

--- a/Hackathon2020.Poc01/Controllers/DynamicControllerBase.cs
+++ b/Hackathon2020.Poc01/Controllers/DynamicControllerBase.cs
@@ -2,9 +2,9 @@
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OData.UriParser;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
+++ b/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.7.2" />
-    <PackageReference Include="RapidApi.AspNetCore.OData.Experimental" Version="1.0.2" />
+    <PackageReference Include="RapidApi.AspNetCore.OData.Experimental" Version="1.0.3" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 

--- a/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
+++ b/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
@@ -6,8 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="C:\Users\clhabins\.nuget\packages\rapidapi.aspnetcore.odata.experimental\1.0.2\contentFiles\any\netcoreapp3.1\PropertyContainer.generated.tt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="connectionstring.txt" />
-    <None Remove="project.csdl" />
+    <None Remove="Project.csdl" />
+    <None Remove="Simple.csdl" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +20,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Project.csdl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Simple.csdl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -25,8 +33,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.6" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.7.2" />
     <PackageReference Include="RapidApi.AspNetCore.OData.Experimental" Version="1.0.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
@@ -38,12 +44,6 @@
 
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="C:\Users\clhabins\source\repos\Hackathon2020.Poc01\Microsoft.AspNet.OData.Shared\Query\Expressions\PropertyContainer.generated.cs">
-      <DesignTime>True</DesignTime>
-    </Compile>
   </ItemGroup>
 
 </Project>

--- a/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
+++ b/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
@@ -13,6 +13,7 @@
     <None Remove="connectionstring.txt" />
     <None Remove="Project.csdl" />
     <None Remove="Simple.csdl" />
+    <None Remove="Trippin.csdl" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Simple.csdl">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Trippin.csdl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Hackathon2020.Poc01/Simple.csdl
+++ b/Hackathon2020.Poc01/Simple.csdl
@@ -1,0 +1,110 @@
+﻿<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Hackathon2020.Poc01.Models">
+      <EntityType Name="Task">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="ProjectId" Type="Edm.Int32"/>
+        <Property Name="MilestoneId" Type="Edm.Int32"/>
+        <Property Name="SupervisorId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Milestone" Type="Hackathon2020.Poc01.Models.Milestone">
+          <ReferentialConstraint Property="MilestoneId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Supervisor" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="SupervisorId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="Milestone">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ProjectId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+      </EntityType>
+      <EntityType Name="Employee">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ManagerId" Type="Edm.Int32"/>
+        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Reports" Type="Collection(Hackathon2020.Poc01.Models.Employee)"/>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+      </EntityType>
+      <EntityType Name="Project">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ManagerId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+        <NavigationProperty Name="Milestones" Type="Collection(Hackathon2020.Poc01.Models.Milestone)"/>
+      </EntityType>
+      <EntityType Name="Product">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Supplier">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="Website" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Customer">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+      </EntityType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
+      <Function Name="KeyProjects" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
+        <ReturnType Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
+      </Function>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Employees" EntityType="Hackathon2020.Poc01.Models.Employee">
+          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
+          <NavigationPropertyBinding Path="Reports" Target="Employees"/>
+        </EntitySet>
+        <EntitySet Name="Projects" EntityType="Hackathon2020.Poc01.Models.Project">
+          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
+        </EntitySet>
+        <EntitySet Name="Products" EntityType="Hackathon2020.Poc01.Models.Product" />
+        <EntitySet Name="Suppliers" EntityType="Hackathon2020.Poc01.Models.Supplier" />
+        <EntitySet Name="Customers" EntityType="Hackathon2020.Poc01.Models.Customer" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/Hackathon2020.Poc01/Startup.cs
+++ b/Hackathon2020.Poc01/Startup.cs
@@ -2,6 +2,7 @@ using EdmObjectsGenerator;
 using Hackathon2020.Poc01.Data;
 using Hackathon2020.Poc01.Lib;
 using Microsoft.AspNet.OData.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNet.OData.Routing.Conventions;
@@ -14,7 +15,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using System;
-using System.Data.Entity;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -41,9 +41,12 @@ namespace Hackathon2020.Poc01
 
             var connectionString = File.ReadAllText(DbContextConstants.ConnectionStringFile).Trim();
 
-            DbContext dbContext = (DbContext)Activator.CreateInstance(contextType, new string[] { connectionString });
+            var optionsBuilder = new DbContextOptionsBuilder();
+            var dbContextOptions = optionsBuilder.UseInMemoryDatabase("RapidApiDB").Options;
+
+            DbContext dbContext = (DbContext)Activator.CreateInstance(contextType, new object[] { dbContextOptions });
          
-            dbContext.Database.CreateIfNotExists();
+            //dbContext.Database.CreateIfNotExists();
 
             services.AddSingleton(this.Configuration);
             services.AddSingleton(typeof(DbContext), dbContext);

--- a/Hackathon2020.Poc01/Trippin.csdl
+++ b/Hackathon2020.Poc01/Trippin.csdl
@@ -1,0 +1,335 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.OData.SampleService.Models.TripPin" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0" />
+        <Member Name="Female" Value="1" />
+        <Member Name="Unknown" Value="2" />
+      </EnumType>
+      <ComplexType Name="City">
+        <Property Name="CountryRegion" Type="Edm.String" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Region" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="Location" OpenType="true">
+        <Property Name="Address" Type="Edm.String" Nullable="false" />
+        <Property Name="City" Type="Microsoft.OData.SampleService.Models.TripPin.City" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="EventLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="BuildingInfo" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="Loc" Type="Edm.GeographyPoint" Nullable="false" SRID="4326" />
+      </ComplexType>
+      <EntityType Name="Photo" HasStream="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>image/jpeg</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="Person" OpenType="true">
+        <Key>
+          <PropertyRef Name="UserName" />
+        </Key>
+        <Property Name="UserName" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" />
+        <Property Name="Emails" Type="Collection(Edm.String)" />
+        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
+        <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
+        <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" />
+        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" ContainsTarget="true" />
+        <NavigationProperty Name="Photo" Type="Microsoft.OData.SampleService.Models.TripPin.Photo" />
+      </EntityType>
+      <EntityType Name="Airline">
+        <Key>
+          <PropertyRef Name="AirlineCode" />
+        </Key>
+        <Property Name="AirlineCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode" />
+        </Key>
+        <Property Name="IcaoCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="IataCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
+        </Property>
+        <Property Name="Location" Type="Microsoft.OData.SampleService.Models.TripPin.AirportLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="PlanItem">
+        <Key>
+          <PropertyRef Name="PlanItemId" />
+        </Key>
+        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ConfirmationCode" Type="Edm.String" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="Duration" Type="Edm.Duration" />
+      </EntityType>
+      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem">
+        <Property Name="SeatNumber" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Microsoft.OData.SampleService.Models.TripPin.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String" Nullable="false" />
+        <NavigationProperty Name="From" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="To" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="Airline" Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Event" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem" OpenType="true">
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="OccursAt" Type="Microsoft.OData.SampleService.Models.TripPin.EventLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId" />
+        </Key>
+        <Property Name="TripId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ShareId" Type="Edm.Guid" />
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Budget" Type="Edm.Single" Nullable="false">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="USD" />
+          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
+        </Property>
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
+        <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
+        <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)" ContainsTarget="true" />
+      </EntityType>
+      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person/Trips/PlanItems/Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+      </Function>
+      <Function Name="GetInvolvedPeople" IsBound="true" IsComposable="true">
+        <Parameter Name="trip" Type="Microsoft.OData.SampleService.Models.TripPin.Trip" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" Nullable="false" />
+      </Function>
+      <Function Name="GetFriendsTrips" IsBound="true" EntitySetPath="person/Friends/Trips" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" Nullable="false" />
+      </Function>
+      <Function Name="GetNearestAirport" IsComposable="true">
+        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+      </Function>
+      <Action Name="ResetDataSource" />
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <EntityContainer Name="DefaultContainer">
+        <EntitySet Name="Photos" EntityType="Microsoft.OData.SampleService.Models.TripPin.Photo">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Photos" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="People" EntityType="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Concurrency</PropertyPath>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="People" />
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Navigability">
+                <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="Friends" />
+                    <PropertyValue Property="Navigability">
+                      <EnumMember>Org.OData.Capabilities.V1.NavigationType/Recursive</EnumMember>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection>
+                  <NavigationPropertyPath>Trips</NavigationPropertyPath>
+                  <NavigationPropertyPath>Friends</NavigationPropertyPath>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airlines" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airline">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airlines" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airport">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airports" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="false" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+            <Record>
+              <PropertyValue Property="Deletable" Bool="false" />
+              <PropertyValue Property="NonDeletableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <Singleton Name="Me" Type="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Me" />
+        </Singleton>
+        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" EntitySet="Airports" IncludeInServiceDocument="true">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" />
+        </FunctionImport>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.SampleService.Models.TripPin.ResetDataSource" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="TripPin service is a sample service for OData V4." />
+      </EntityContainer>
+      <Annotations Target="Microsoft.OData.SampleService.Models.TripPin.DefaultContainer">
+        <Annotation Term="Org.OData.Core.V1.DereferenceableIDs" Bool="true" />
+        <Annotation Term="Org.OData.Core.V1.ConventionalIDs" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.ConformanceLevel">
+          <EnumMember>Org.OData.Capabilities.V1.ConformanceLevelType/Advanced</EnumMember>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
+          <Collection>
+            <String>application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=minimal;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=none;IEEE754Compatible=false;odata.streaming=true</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.FilterFunctions">
+          <Collection>
+            <String>contains</String>
+            <String>endswith</String>
+            <String>startswith</String>
+            <String>length</String>
+            <String>indexof</String>
+            <String>substring</String>
+            <String>tolower</String>
+            <String>toupper</String>
+            <String>trim</String>
+            <String>concat</String>
+            <String>year</String>
+            <String>month</String>
+            <String>day</String>
+            <String>hour</String>
+            <String>minute</String>
+            <String>second</String>
+            <String>round</String>
+            <String>floor</String>
+            <String>ceiling</String>
+            <String>cast</String>
+            <String>isof</String>
+          </Collection>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/Hackathon2020.Poc01/project.csdl
+++ b/Hackathon2020.Poc01/project.csdl
@@ -1,335 +1,110 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+﻿<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:DataServices>
-    <Schema Namespace="Microsoft.OData.SampleService.Models.TripPin" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <EnumType Name="PersonGender">
-        <Member Name="Male" Value="0" />
-        <Member Name="Female" Value="1" />
-        <Member Name="Unknown" Value="2" />
-      </EnumType>
-      <ComplexType Name="City">
-        <Property Name="CountryRegion" Type="Edm.String" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" Nullable="false" />
-        <Property Name="Region" Type="Edm.String" Nullable="false" />
-      </ComplexType>
-      <ComplexType Name="Location" OpenType="true">
-        <Property Name="Address" Type="Edm.String" Nullable="false" />
-        <Property Name="City" Type="Microsoft.OData.SampleService.Models.TripPin.City" Nullable="false" />
-      </ComplexType>
-      <ComplexType Name="EventLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
-        <Property Name="BuildingInfo" Type="Edm.String" />
-      </ComplexType>
-      <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
-        <Property Name="Loc" Type="Edm.GeographyPoint" Nullable="false" SRID="4326" />
-      </ComplexType>
-      <EntityType Name="Photo" HasStream="true">
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Hackathon2020.Poc01.Models">
+      <EntityType Name="Task">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Description" Type="Edm.String"/>
+        <Property Name="ProjectId" Type="Edm.Int32"/>
+        <Property Name="MilestoneId" Type="Edm.Int32"/>
+        <Property Name="SupervisorId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Milestone" Type="Hackathon2020.Poc01.Models.Milestone">
+          <ReferentialConstraint Property="MilestoneId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Supervisor" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="SupervisorId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="Milestone">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ProjectId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
+          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+      </EntityType>
+      <EntityType Name="Employee">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ManagerId" Type="Edm.Int32"/>
+        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Reports" Type="Collection(Hackathon2020.Poc01.Models.Employee)"/>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+      </EntityType>
+      <EntityType Name="Project">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="ManagerId" Type="Edm.Int32"/>
+        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
+        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
+          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
+        <NavigationProperty Name="Milestones" Type="Collection(Hackathon2020.Poc01.Models.Milestone)"/>
+      </EntityType>
+      <EntityType Name="Product">
         <Key>
           <PropertyRef Name="Id" />
         </Key>
-        <Property Name="Id" Type="Edm.Int64" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
         <Property Name="Name" Type="Edm.String" />
-        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
-          <Collection>
-            <String>image/jpeg</String>
-          </Collection>
-        </Annotation>
+        <Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false" />
       </EntityType>
-      <EntityType Name="Person" OpenType="true">
+      <EntityType Name="Supplier">
         <Key>
-          <PropertyRef Name="UserName" />
+          <PropertyRef Name="Id" />
         </Key>
-        <Property Name="UserName" Type="Edm.String" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
-        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
-        <Property Name="LastName" Type="Edm.String" Nullable="false" />
-        <Property Name="Emails" Type="Collection(Edm.String)" />
-        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
-        <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
-        <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
-        </Property>
-        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" />
-        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" ContainsTarget="true" />
-        <NavigationProperty Name="Photo" Type="Microsoft.OData.SampleService.Models.TripPin.Photo" />
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="Website" Type="Edm.String" />
       </EntityType>
-      <EntityType Name="Airline">
+      <EntityType Name="Customer">
         <Key>
-          <PropertyRef Name="AirlineCode" />
+          <PropertyRef Name="Id" />
         </Key>
-        <Property Name="AirlineCode" Type="Edm.String" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
-        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
       </EntityType>
-      <EntityType Name="Airport">
-        <Key>
-          <PropertyRef Name="IcaoCode" />
-        </Key>
-        <Property Name="IcaoCode" Type="Edm.String" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
-        <Property Name="Name" Type="Edm.String" Nullable="false" />
-        <Property Name="IataCode" Type="Edm.String" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
-        </Property>
-        <Property Name="Location" Type="Microsoft.OData.SampleService.Models.TripPin.AirportLocation" Nullable="false" />
-      </EntityType>
-      <EntityType Name="PlanItem">
-        <Key>
-          <PropertyRef Name="PlanItemId" />
-        </Key>
-        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
-        <Property Name="ConfirmationCode" Type="Edm.String" />
-        <Property Name="StartsAt" Type="Edm.DateTimeOffset" />
-        <Property Name="EndsAt" Type="Edm.DateTimeOffset" />
-        <Property Name="Duration" Type="Edm.Duration" />
-      </EntityType>
-      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem">
-        <Property Name="SeatNumber" Type="Edm.String" />
-      </EntityType>
-      <EntityType Name="Flight" BaseType="Microsoft.OData.SampleService.Models.TripPin.PublicTransportation">
-        <Property Name="FlightNumber" Type="Edm.String" Nullable="false" />
-        <NavigationProperty Name="From" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
-        <NavigationProperty Name="To" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
-        <NavigationProperty Name="Airline" Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
-      </EntityType>
-      <EntityType Name="Event" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem" OpenType="true">
-        <Property Name="Description" Type="Edm.String" />
-        <Property Name="OccursAt" Type="Microsoft.OData.SampleService.Models.TripPin.EventLocation" Nullable="false" />
-      </EntityType>
-      <EntityType Name="Trip">
-        <Key>
-          <PropertyRef Name="TripId" />
-        </Key>
-        <Property Name="TripId" Type="Edm.Int32" Nullable="false">
-          <Annotation Term="Org.OData.Core.V1.Permissions">
-            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
-          </Annotation>
-        </Property>
-        <Property Name="ShareId" Type="Edm.Guid" />
-        <Property Name="Description" Type="Edm.String" />
-        <Property Name="Name" Type="Edm.String" Nullable="false" />
-        <Property Name="Budget" Type="Edm.Single" Nullable="false">
-          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="USD" />
-          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
-        </Property>
-        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
-        <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
-        <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)" ContainsTarget="true" />
-      </EntityType>
-      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person/Trips/PlanItems/Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" IsComposable="true">
-        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
-        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
+      <Function Name="KeyProjects" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
+        <ReturnType Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
       </Function>
-      <Function Name="GetInvolvedPeople" IsBound="true" IsComposable="true">
-        <Parameter Name="trip" Type="Microsoft.OData.SampleService.Models.TripPin.Trip" Nullable="false" />
-        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" Nullable="false" />
-      </Function>
-      <Function Name="GetFriendsTrips" IsBound="true" EntitySetPath="person/Friends/Trips" IsComposable="true">
-        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
-        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
-        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" Nullable="false" />
-      </Function>
-      <Function Name="GetNearestAirport" IsComposable="true">
-        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
-        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
-        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
-      </Function>
-      <Action Name="ResetDataSource" />
-      <Action Name="ShareTrip" IsBound="true">
-        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
-        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
-        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
-      </Action>
-      <EntityContainer Name="DefaultContainer">
-        <EntitySet Name="Photos" EntityType="Microsoft.OData.SampleService.Models.TripPin.Photo">
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Photos" />
-          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-            <Record>
-              <PropertyValue Property="Searchable" Bool="true" />
-              <PropertyValue Property="UnsupportedExpressions">
-                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-            <Record>
-              <PropertyValue Property="Insertable" Bool="true" />
-              <PropertyValue Property="NonInsertableNavigationProperties">
-                <Collection />
-              </PropertyValue>
-            </Record>
-          </Annotation>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Employees" EntityType="Hackathon2020.Poc01.Models.Employee">
+          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
+          <NavigationPropertyBinding Path="Reports" Target="Employees"/>
         </EntitySet>
-        <EntitySet Name="People" EntityType="Microsoft.OData.SampleService.Models.TripPin.Person">
-          <NavigationPropertyBinding Path="Friends" Target="People" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
-          <NavigationPropertyBinding Path="Photo" Target="Photos" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
-          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
-            <Collection>
-              <PropertyPath>Concurrency</PropertyPath>
-            </Collection>
-          </Annotation>
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="People" />
-          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
-            <Record>
-              <PropertyValue Property="Navigability">
-                <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
-              </PropertyValue>
-              <PropertyValue Property="RestrictedProperties">
-                <Collection>
-                  <Record>
-                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="Friends" />
-                    <PropertyValue Property="Navigability">
-                      <EnumMember>Org.OData.Capabilities.V1.NavigationType/Recursive</EnumMember>
-                    </PropertyValue>
-                  </Record>
-                </Collection>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-            <Record>
-              <PropertyValue Property="Searchable" Bool="true" />
-              <PropertyValue Property="UnsupportedExpressions">
-                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-            <Record>
-              <PropertyValue Property="Insertable" Bool="true" />
-              <PropertyValue Property="NonInsertableNavigationProperties">
-                <Collection>
-                  <NavigationPropertyPath>Trips</NavigationPropertyPath>
-                  <NavigationPropertyPath>Friends</NavigationPropertyPath>
-                </Collection>
-              </PropertyValue>
-            </Record>
-          </Annotation>
+        <EntitySet Name="Projects" EntityType="Hackathon2020.Poc01.Models.Project">
+          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
         </EntitySet>
-        <EntitySet Name="Airlines" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airline">
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airlines" />
-          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-            <Record>
-              <PropertyValue Property="Searchable" Bool="true" />
-              <PropertyValue Property="UnsupportedExpressions">
-                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-            <Record>
-              <PropertyValue Property="Insertable" Bool="true" />
-              <PropertyValue Property="NonInsertableNavigationProperties">
-                <Collection />
-              </PropertyValue>
-            </Record>
-          </Annotation>
-        </EntitySet>
-        <EntitySet Name="Airports" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airport">
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airports" />
-          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
-            <Record>
-              <PropertyValue Property="Searchable" Bool="true" />
-              <PropertyValue Property="UnsupportedExpressions">
-                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
-            <Record>
-              <PropertyValue Property="Insertable" Bool="false" />
-              <PropertyValue Property="NonInsertableNavigationProperties">
-                <Collection />
-              </PropertyValue>
-            </Record>
-          </Annotation>
-          <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
-            <Record>
-              <PropertyValue Property="Deletable" Bool="false" />
-              <PropertyValue Property="NonDeletableNavigationProperties">
-                <Collection />
-              </PropertyValue>
-            </Record>
-          </Annotation>
-        </EntitySet>
-        <Singleton Name="Me" Type="Microsoft.OData.SampleService.Models.TripPin.Person">
-          <NavigationPropertyBinding Path="Friends" Target="People" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
-          <NavigationPropertyBinding Path="Photo" Target="Photos" />
-          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Me" />
-        </Singleton>
-        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" EntitySet="Airports" IncludeInServiceDocument="true">
-          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" />
-        </FunctionImport>
-        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.SampleService.Models.TripPin.ResetDataSource" />
-        <Annotation Term="Org.OData.Core.V1.Description" String="TripPin service is a sample service for OData V4." />
+        <EntitySet Name="Products" EntityType="Hackathon2020.Poc01.Models.Product" />
+        <EntitySet Name="Suppliers" EntityType="Hackathon2020.Poc01.Models.Supplier" />
+        <EntitySet Name="Customers" EntityType="Hackathon2020.Poc01.Models.Customer" />
       </EntityContainer>
-      <Annotations Target="Microsoft.OData.SampleService.Models.TripPin.DefaultContainer">
-        <Annotation Term="Org.OData.Core.V1.DereferenceableIDs" Bool="true" />
-        <Annotation Term="Org.OData.Core.V1.ConventionalIDs" Bool="true" />
-        <Annotation Term="Org.OData.Capabilities.V1.ConformanceLevel">
-          <EnumMember>Org.OData.Capabilities.V1.ConformanceLevelType/Advanced</EnumMember>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
-          <Collection>
-            <String>application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true</String>
-            <String>application/json;odata.metadata=minimal;IEEE754Compatible=false;odata.streaming=true</String>
-            <String>application/json;odata.metadata=none;IEEE754Compatible=false;odata.streaming=true</String>
-          </Collection>
-        </Annotation>
-        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="true" />
-        <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
-        <Annotation Term="Org.OData.Capabilities.V1.FilterFunctions">
-          <Collection>
-            <String>contains</String>
-            <String>endswith</String>
-            <String>startswith</String>
-            <String>length</String>
-            <String>indexof</String>
-            <String>substring</String>
-            <String>tolower</String>
-            <String>toupper</String>
-            <String>trim</String>
-            <String>concat</String>
-            <String>year</String>
-            <String>month</String>
-            <String>day</String>
-            <String>hour</String>
-            <String>minute</String>
-            <String>second</String>
-            <String>round</String>
-            <String>floor</String>
-            <String>ceiling</String>
-            <String>cast</String>
-            <String>isof</String>
-          </Collection>
-        </Annotation>
-      </Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/Hackathon2020.Poc01/project.csdl
+++ b/Hackathon2020.Poc01/project.csdl
@@ -1,110 +1,335 @@
-﻿<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
   <edmx:DataServices>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Hackathon2020.Poc01.Models">
-      <EntityType Name="Task">
-        <Key>
-          <PropertyRef Name="Id"/>
-        </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="Description" Type="Edm.String"/>
-        <Property Name="ProjectId" Type="Edm.Int32"/>
-        <Property Name="MilestoneId" Type="Edm.Int32"/>
-        <Property Name="SupervisorId" Type="Edm.Int32"/>
-        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
-          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Milestone" Type="Hackathon2020.Poc01.Models.Milestone">
-          <ReferentialConstraint Property="MilestoneId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Supervisor" Type="Hackathon2020.Poc01.Models.Employee">
-          <ReferentialConstraint Property="SupervisorId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-      </EntityType>
-      <EntityType Name="Milestone">
-        <Key>
-          <PropertyRef Name="Id"/>
-        </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="Name" Type="Edm.String"/>
-        <Property Name="ProjectId" Type="Edm.Int32"/>
-        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <NavigationProperty Name="Project" Type="Hackathon2020.Poc01.Models.Project">
-          <ReferentialConstraint Property="ProjectId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
-      </EntityType>
-      <EntityType Name="Employee">
-        <Key>
-          <PropertyRef Name="Id"/>
-        </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="Name" Type="Edm.String"/>
-        <Property Name="ManagerId" Type="Edm.Int32"/>
-        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
-          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Reports" Type="Collection(Hackathon2020.Poc01.Models.Employee)"/>
-        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
-      </EntityType>
-      <EntityType Name="Project">
-        <Key>
-          <PropertyRef Name="Id"/>
-        </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
-        <Property Name="Name" Type="Edm.String"/>
-        <Property Name="ManagerId" Type="Edm.Int32"/>
-        <Property Name="Start" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <Property Name="End" Type="Edm.DateTimeOffset" Nullable="false"/>
-        <NavigationProperty Name="Manager" Type="Hackathon2020.Poc01.Models.Employee">
-          <ReferentialConstraint Property="ManagerId" ReferencedProperty="Id"/>
-        </NavigationProperty>
-        <NavigationProperty Name="Tasks" Type="Collection(Hackathon2020.Poc01.Models.Task)"/>
-        <NavigationProperty Name="Milestones" Type="Collection(Hackathon2020.Poc01.Models.Milestone)"/>
-      </EntityType>
-      <EntityType Name="Product">
+    <Schema Namespace="Microsoft.OData.SampleService.Models.TripPin" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0" />
+        <Member Name="Female" Value="1" />
+        <Member Name="Unknown" Value="2" />
+      </EnumType>
+      <ComplexType Name="City">
+        <Property Name="CountryRegion" Type="Edm.String" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Region" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="Location" OpenType="true">
+        <Property Name="Address" Type="Edm.String" Nullable="false" />
+        <Property Name="City" Type="Microsoft.OData.SampleService.Models.TripPin.City" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="EventLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="BuildingInfo" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="AirportLocation" BaseType="Microsoft.OData.SampleService.Models.TripPin.Location" OpenType="true">
+        <Property Name="Loc" Type="Edm.GeographyPoint" Nullable="false" SRID="4326" />
+      </ComplexType>
+      <EntityType Name="Photo" HasStream="true">
         <Key>
           <PropertyRef Name="Id" />
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Id" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
         <Property Name="Name" Type="Edm.String" />
-        <Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>image/jpeg</String>
+          </Collection>
+        </Annotation>
       </EntityType>
-      <EntityType Name="Supplier">
+      <EntityType Name="Person" OpenType="true">
         <Key>
-          <PropertyRef Name="Id" />
+          <PropertyRef Name="UserName" />
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" />
-        <Property Name="Website" Type="Edm.String" />
+        <Property Name="UserName" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" />
+        <Property Name="Emails" Type="Collection(Edm.String)" />
+        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
+        <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
+        <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" />
+        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" ContainsTarget="true" />
+        <NavigationProperty Name="Photo" Type="Microsoft.OData.SampleService.Models.TripPin.Photo" />
       </EntityType>
-      <EntityType Name="Customer">
+      <EntityType Name="Airline">
         <Key>
-          <PropertyRef Name="Id" />
+          <PropertyRef Name="AirlineCode" />
         </Key>
-        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" />
+        <Property Name="AirlineCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
       </EntityType>
-    </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
-      <Function Name="KeyProjects" IsBound="true">
-        <Parameter Name="bindingParameter" Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
-        <ReturnType Type="Collection(Hackathon2020.Poc01.Models.Project)"/>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode" />
+        </Key>
+        <Property Name="IcaoCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="IataCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
+        </Property>
+        <Property Name="Location" Type="Microsoft.OData.SampleService.Models.TripPin.AirportLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="PlanItem">
+        <Key>
+          <PropertyRef Name="PlanItemId" />
+        </Key>
+        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ConfirmationCode" Type="Edm.String" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="Duration" Type="Edm.Duration" />
+      </EntityType>
+      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem">
+        <Property Name="SeatNumber" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Microsoft.OData.SampleService.Models.TripPin.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String" Nullable="false" />
+        <NavigationProperty Name="From" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="To" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="Airline" Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Event" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem" OpenType="true">
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="OccursAt" Type="Microsoft.OData.SampleService.Models.TripPin.EventLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId" />
+        </Key>
+        <Property Name="TripId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ShareId" Type="Edm.Guid" />
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Budget" Type="Edm.Single" Nullable="false">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="USD" />
+          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
+        </Property>
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
+        <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
+        <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)" ContainsTarget="true" />
+      </EntityType>
+      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person/Trips/PlanItems/Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
       </Function>
-      <EntityContainer Name="Container">
-        <EntitySet Name="Employees" EntityType="Hackathon2020.Poc01.Models.Employee">
-          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
-          <NavigationPropertyBinding Path="Reports" Target="Employees"/>
+      <Function Name="GetInvolvedPeople" IsBound="true" IsComposable="true">
+        <Parameter Name="trip" Type="Microsoft.OData.SampleService.Models.TripPin.Trip" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" Nullable="false" />
+      </Function>
+      <Function Name="GetFriendsTrips" IsBound="true" EntitySetPath="person/Friends/Trips" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" Nullable="false" />
+      </Function>
+      <Function Name="GetNearestAirport" IsComposable="true">
+        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+      </Function>
+      <Action Name="ResetDataSource" />
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <EntityContainer Name="DefaultContainer">
+        <EntitySet Name="Photos" EntityType="Microsoft.OData.SampleService.Models.TripPin.Photo">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Photos" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
         </EntitySet>
-        <EntitySet Name="Projects" EntityType="Hackathon2020.Poc01.Models.Project">
-          <NavigationPropertyBinding Path="Manager" Target="Employees"/>
+        <EntitySet Name="People" EntityType="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Concurrency</PropertyPath>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="People" />
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Navigability">
+                <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="Friends" />
+                    <PropertyValue Property="Navigability">
+                      <EnumMember>Org.OData.Capabilities.V1.NavigationType/Recursive</EnumMember>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection>
+                  <NavigationPropertyPath>Trips</NavigationPropertyPath>
+                  <NavigationPropertyPath>Friends</NavigationPropertyPath>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
         </EntitySet>
-        <EntitySet Name="Products" EntityType="Hackathon2020.Poc01.Models.Product" />
-        <EntitySet Name="Suppliers" EntityType="Hackathon2020.Poc01.Models.Supplier" />
-        <EntitySet Name="Customers" EntityType="Hackathon2020.Poc01.Models.Customer" />
+        <EntitySet Name="Airlines" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airline">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airlines" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airport">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airports" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="false" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+            <Record>
+              <PropertyValue Property="Deletable" Bool="false" />
+              <PropertyValue Property="NonDeletableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <Singleton Name="Me" Type="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline" Target="Airlines" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From" Target="Airports" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Me" />
+        </Singleton>
+        <FunctionImport Name="GetNearestAirport" Function="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" EntitySet="Airports" IncludeInServiceDocument="true">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport" />
+        </FunctionImport>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.SampleService.Models.TripPin.ResetDataSource" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="TripPin service is a sample service for OData V4." />
       </EntityContainer>
+      <Annotations Target="Microsoft.OData.SampleService.Models.TripPin.DefaultContainer">
+        <Annotation Term="Org.OData.Core.V1.DereferenceableIDs" Bool="true" />
+        <Annotation Term="Org.OData.Core.V1.ConventionalIDs" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.ConformanceLevel">
+          <EnumMember>Org.OData.Capabilities.V1.ConformanceLevelType/Advanced</EnumMember>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
+          <Collection>
+            <String>application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=minimal;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=none;IEEE754Compatible=false;odata.streaming=true</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.FilterFunctions">
+          <Collection>
+            <String>contains</String>
+            <String>endswith</String>
+            <String>startswith</String>
+            <String>length</String>
+            <String>indexof</String>
+            <String>substring</String>
+            <String>tolower</String>
+            <String>toupper</String>
+            <String>trim</String>
+            <String>concat</String>
+            <String>year</String>
+            <String>month</String>
+            <String>day</String>
+            <String>hour</String>
+            <String>minute</String>
+            <String>second</String>
+            <String>round</String>
+            <String>floor</String>
+            <String>ceiling</String>
+            <String>cast</String>
+            <String>isof</String>
+          </Collection>
+        </Annotation>
+      </Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
- Migrate from EF to EF Core
- Use EF Core in-memory database
- Replace Trippin as reference CSDL in favour of the simpler CSDL to avoid EF Core errors, e.g. complex types and collection properties are not supported, we'd need additional configuration or manual mapping to get them to work