### PR TITLE
Seed data

### DIFF
--- a/DataLib/DataLib.csproj
+++ b/DataLib/DataLib.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/DataLib/IDataSet.cs
+++ b/DataLib/IDataSet.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DataLib
+{
+    public interface IDataSet<TEntity>: IQueryable<TEntity>, IEnumerable<TEntity>, IEnumerable, IQueryable
+    {
+        TEntity Add(TEntity entity);
+        void Remove(TEntity entity);
+        void Update(TEntity entity);
+        TEntity FindByKey(params object[] keysValues);
+    }
+}

--- a/DataLib/IDataStore.cs
+++ b/DataLib/IDataStore.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataLib
+{
+    public interface IDataStore
+    {
+        IDataSet<TEntity> Set<TEntity>();
+        void SaveChanges();
+        Task SaveChangesAsync();
+    }
+}

--- a/DataLib/ListDataSet.cs
+++ b/DataLib/ListDataSet.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace DataLib
+{
+    public class ListDataSet<TEntity> : IDataSet<TEntity>
+    {
+        List<TEntity> data = new List<TEntity>();
+
+        Type IQueryable.ElementType => typeof(TEntity);
+
+        Expression IQueryable.Expression => data.AsQueryable().Expression;
+
+        IQueryProvider IQueryable.Provider => data.AsQueryable().Provider;
+
+        public TEntity Add(TEntity entity)
+        {
+            var keys = GetKeysValues(entity);
+
+            foreach (var key in keys)
+            {
+                if (key == null)
+                {
+                    throw new Exception("Key cannot be null");
+                }
+            }
+
+            var duplicate = FindByKey(keys);
+
+            if (duplicate != null)
+            {
+                throw new Exception("Duplicate key");
+            }
+
+            InitializeListProperties(entity);
+            data.Add(entity);
+
+            return entity;
+        }
+
+        public TEntity FindByKey(params object[] keysValues)
+        {
+            return data.FirstOrDefault(entity => EntityMatchesKeys(entity, keysValues));
+        }
+
+        IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator()
+        {
+            return data.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return data.GetEnumerator();
+        }
+
+        public void Remove(TEntity entity)
+        {
+            data.Remove(entity);
+        }
+
+        public void Update(TEntity entity)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        private IEnumerable<PropertyInfo> GetKeyProperties()
+        {
+            var type = typeof(TEntity);
+            return type.GetProperties().Where(p => p.GetCustomAttributes(typeof(KeyAttribute), false).Any());
+        }
+
+        private bool EntityMatchesKeys(TEntity entity, params object[] keysValues)
+        {
+            var keyFields = GetKeyProperties();
+            var kvps = keyFields.Zip(keysValues, (k, v) => new KeyValuePair<PropertyInfo, object>(k, v));
+            foreach (var kvp in kvps)
+            {
+                if (!kvp.Key.GetValue(entity).Equals(kvp.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private object[] GetKeysValues(TEntity entity)
+        {
+            var values = new List<object>();
+            var keyFields = GetKeyProperties();
+            foreach (var field in keyFields)
+            {
+                values.Add(field.GetValue(entity));
+            }
+
+            return values.ToArray();
+        }
+
+        private void InitializeListProperties(TEntity entity)
+        {
+            var properties = typeof(TEntity).GetProperties();
+            var listOfType = typeof(List<>);
+
+            foreach (var prop in properties)
+            {
+                if (!prop.PropertyType.IsGenericType) continue;
+                var elementType = prop.PropertyType.GetGenericArguments()[0];
+                var listType = listOfType.MakeGenericType(elementType);
+                if (!listType.IsAssignableFrom(prop.PropertyType)) continue;
+
+                var list = prop.GetValue(entity);
+                if (list == null)
+                {
+                    prop.SetValue(entity, Activator.CreateInstance(listType));
+                }
+            }
+        }
+    }
+}

--- a/DataLib/ListDataStore.cs
+++ b/DataLib/ListDataStore.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataLib
+{
+    public abstract class ListDataStore : IDataStore
+    {
+        public ListDataStore()
+        {
+            InitDataSets();
+        }
+        public virtual void SaveChanges()
+        {
+        }
+
+        public virtual Task SaveChangesAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public IDataSet<TEntity> Set<TEntity>()
+        {
+            var type = this.GetType();
+            var targetSetType = typeof(IDataSet<>).MakeGenericType(typeof(TEntity));
+
+            var targetProp = type.GetProperties().FirstOrDefault(prop => targetSetType.IsAssignableFrom(prop.PropertyType));
+            if (targetProp == null)
+            {
+                throw new Exception("Cannot find DataSet with that type");
+            }
+
+            var dataSet = targetProp.GetValue(this) as IDataSet<TEntity>;
+
+            return dataSet;
+        }
+
+        private void InitDataSets()
+        {
+            var setOf = typeof(ListDataSet<>);
+            var properties = this.GetType().GetProperties();
+
+            foreach (var prop in properties)
+            {
+                if (!prop.PropertyType.IsGenericType)
+                {
+                    continue;
+                }
+
+                var entityType = prop.PropertyType.GetGenericArguments()[0];
+                var setType = setOf.MakeGenericType(entityType);
+
+                if (!setType.IsAssignableFrom(prop.PropertyType))
+                {
+                    continue;
+                }
+
+                var newSet = Activator.CreateInstance(setType);
+                prop.SetValue(this, newSet);
+            }
+        }
+
+       
+    }
+}

--- a/DummyTests/DummyTests.csproj
+++ b/DummyTests/DummyTests.csproj
@@ -16,6 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoBogus" Version="2.12.0" />
+    <PackageReference Include="Bogus" Version="31.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EdmObjectsGenerator\EdmObjectsGenerator.csproj" />
   </ItemGroup>
 

--- a/DummyTests/Program.cs
+++ b/DummyTests/Program.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using AutoBogus;
 using EdmObjectsGenerator;
 
 namespace DummyTests
@@ -8,8 +13,46 @@ namespace DummyTests
         static void Main(string[] args)
         {
             Console.WriteLine("");
-            DbContextGenerator generator = new DbContextGenerator();
-            var context = generator.GenerateDbContext(@"SampleModel.xml");
+            //DbContextGenerator generator = new DbContextGenerator();
+            //var context = generator.GenerateDbContext(@"SampleModel.xml");
+
+            GenerateData();
         }
+
+        static void GenerateData()
+        {
+            var argType = typeof(Action<>).MakeGenericType(typeof(IAutoGenerateConfigBuilder));
+            var person = AutoFaker.Generate<Person>();
+            var generatMethod = typeof(AutoFaker).GetMethod("Generate", new[] { argType });
+            var generatePerson = generatMethod.MakeGenericMethod(typeof(Person));
+            object p = generatePerson.Invoke(null, new object[] { null }) ;
+        }
+
+        
+    }
+
+    class Person
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public List<Person> Friends { get; set; }
+        public List<string> Emails { get; set; }
+        public Address Address { get; set; }
+    }
+
+    class Sport
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [ComplexType]
+    class Address
+    {
+        public string City { get; set; }
+        public string Country { get; set; }
     }
 }

--- a/EdmObjectsGenerator/DbContextGenerator.cs
+++ b/EdmObjectsGenerator/DbContextGenerator.cs
@@ -13,6 +13,7 @@
     using Microsoft.OData.Edm;
     using Microsoft.OData.Edm.Csdl;
     using Microsoft.OData.Edm.Validation;
+    using DataLib;
 
     [Serializable]
     public class DbContextGenerator
@@ -122,18 +123,23 @@
             
 
             //generate the DbContext type
-            var entitiesBuilder = moduleBuilder.DefineType(dbContextName, TypeAttributes.Class | TypeAttributes.Public, typeof(DbContext));
-            var dbContextType = typeof(DbContext);
-            //entitiesBuilder.CreateDefaultConstructor(dbContextType, $"name={dbContextName}");
-            //entitiesBuilder.CreateConnectionStringConstructor(dbContextType);
-            entitiesBuilder.CreateContextOptionsConstructor(dbContextType);
+            // TODO: this created an EfCore DbContext
+            //var entitiesBuilder = moduleBuilder.DefineType(dbContextName, TypeAttributes.Class | TypeAttributes.Public, typeof(DbContext));
+            //var dbContextType = typeof(DbContext);
+            ////entitiesBuilder.CreateDefaultConstructor(dbContextType, $"name={dbContextName}");
+            ////entitiesBuilder.CreateConnectionStringConstructor(dbContextType);
+            //entitiesBuilder.CreateContextOptionsConstructor(dbContextType);
+
+            var entitiesBuilder = moduleBuilder.DefineType(dbContextName, TypeAttributes.Class | TypeAttributes.Public, typeof(ListDataStore));
+            var dbContextType = typeof(ListDataStore);
 
             foreach (var entitySet in model.EntityContainer.EntitySets())
             {
                 TypeBuilderInfo entityType = _typeBuildersDict.FirstOrDefault(t => t.Key == entitySet.EntityType().FullName()).Value;
                 if (entityType != null)
                 {
-                    Type listOf = typeof(DbSet<>);
+                    //Type listOf = typeof(DbSet<>);
+                    Type listOf = typeof(ListDataSet<>);
                     Type selfContained = listOf.MakeGenericType(entityType.Builder);
                     PropertyBuilderHelper.BuildProperty(entitiesBuilder, entitySet.Name, selfContained);
                 }

--- a/EdmObjectsGenerator/EdmObjectsGenerator.csproj
+++ b/EdmObjectsGenerator/EdmObjectsGenerator.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.OData.Edm" Version="7.6.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DataLib\DataLib.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Hackathon2020.Poc01/Controllers/DynamicControllerBase.cs
+++ b/Hackathon2020.Poc01/Controllers/DynamicControllerBase.cs
@@ -9,16 +9,17 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNet.OData.Routing;
+using DataLib;
 
 namespace Hackathon2020.Poc01.Controllers
 {
     public class DynamicControllerBase<TEntity> : ODataController where TEntity : class
     {
-        private readonly DbContext _db;
+        private readonly IDataStore _db;
 
         private Microsoft.AspNet.OData.Routing.ODataPath ODataPath { get => HttpContext.ODataFeature().Path; }
 
-        public DynamicControllerBase(DbContext db)
+        public DynamicControllerBase(IDataStore db)
         {
             _db = db;
         }
@@ -34,7 +35,7 @@ namespace Hackathon2020.Poc01.Controllers
                 return NotFound();
             }
 
-            var entity = _db.Set<TEntity>().Find(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
+            var entity = _db.Set<TEntity>().FindByKey(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
             if (entity == null)
             {
                 return NotFound();
@@ -54,7 +55,7 @@ namespace Hackathon2020.Poc01.Controllers
 
             var added = _db.Set<TEntity>().Add(data);
             _db.SaveChanges();
-            return Ok(added.Entity);
+            return Ok(added);
         }
 
         public ActionResult Patch(Delta<TEntity> patch)
@@ -74,7 +75,7 @@ namespace Hackathon2020.Poc01.Controllers
             }
 
             var dbSet = _db.Set<TEntity>();
-            var entity = dbSet.Find(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
+            var entity = dbSet.FindByKey(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
 
             if (entity == null)
             {
@@ -101,7 +102,7 @@ namespace Hackathon2020.Poc01.Controllers
                 return NotFound();
             }
 
-            var entity = _db.Set<TEntity>().Find(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
+            var entity = _db.Set<TEntity>().FindByKey(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
             if (entity == null)
             {
                 return NotFound();
@@ -118,9 +119,9 @@ namespace Hackathon2020.Poc01.Controllers
 
             try
             {
-                var updated = _db.Update(entity);
+                //var updated = _db.Update(entity);
                 _db.SaveChanges();
-                return Ok(updated.Entity);
+                return Ok(entity);
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -159,7 +160,7 @@ namespace Hackathon2020.Poc01.Controllers
                 return NotFound();
             }
 
-            var dbSetMethod = typeof(DbContext).GetMethod("Set").MakeGenericMethod(relatedType);
+            var dbSetMethod = _db.GetType().GetMethod("Set").MakeGenericMethod(relatedType);
             var relatedDbSet = dbSetMethod.Invoke(_db, Array.Empty<object>());
 
             
@@ -246,7 +247,7 @@ namespace Hackathon2020.Poc01.Controllers
                 return NotFound();
             }
 
-            var entity = _db.Set<TEntity>().Find(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
+            var entity = _db.Set<TEntity>().FindByKey(keySegment.Keys.Select(kvp => kvp.Value).ToArray());
             if (entity == null)
             {
                 return NotFound();

--- a/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
+++ b/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoBogus" Version="2.12.0" />
     <PackageReference Include="Azure.Storage.Files.Shares" Version="12.5.0" />
+    <PackageReference Include="Bogus" Version="31.0.3" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />

--- a/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
+++ b/Hackathon2020.Poc01/Hackathon2020.Poc01.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <!-- <ProjectReference Include="..\..\WebApi\src\Microsoft.AspNetCore.OData\Microsoft.AspNetCore.OData.csproj" /> -->
+    <ProjectReference Include="..\DataLib\DataLib.csproj" />
     <ProjectReference Include="..\EdmObjectsGenerator\EdmObjectsGenerator.csproj" />
   </ItemGroup>
 

--- a/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
+++ b/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.OData.Edm;
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AutoBogus;
+using Bogus;
+
+namespace Hackathon2020.Poc01.Lib.Seeder
+{
+    public class DataSeeder
+    {
+        IEdmModel model;
+        DbContext context;
+        IEnumerable<TypeInfo> types;
+
+        public DataSeeder(IEdmModel model, DbContext context, IEnumerable<TypeInfo> types)
+        {
+            this.model = model;
+            this.context = context;
+            this.types = types;
+        }
+        public async Task SeedData()
+        {
+            foreach (var entitySet in model.EntityContainer.EntitySets())
+            {
+                SeedEntitySet(entitySet);
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        private void SeedEntitySet(IEdmEntitySet entitySet)
+        {
+            var edmEntityType = entitySet.EntityType();
+            var entityType = types.First(t => t.Name == edmEntityType.Name);
+
+            var dbSet = context.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(context, Array.Empty<object>());
+            var addMethod = dbSet.GetType().GetMethod("Add");
+            var generator = GetGeneratorForType(entityType);
+
+            int count = 100;
+
+            for (int i = 0; i < count; i++)
+            {
+                var obj = generator.Invoke(null, new object[] { });
+                addMethod.Invoke(dbSet, new[] { obj });
+            }
+        }
+
+        private MethodInfo GetGeneratorForType(Type type)
+        {
+            var argType = typeof(Action<>).MakeGenericType(typeof(IAutoGenerateConfigBuilder));
+            var generatMethod = typeof(AutoFaker).GetMethod("Generate", new[] { argType });
+            var generateType = generatMethod.MakeGenericMethod(type);
+            return generateType;
+        }
+    }
+}

--- a/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
+++ b/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
@@ -1,22 +1,24 @@
 ﻿using Microsoft.OData.Edm;
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
+using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using AutoBogus;
 using Bogus;
+using DataLib;
+using System.Collections;
 
 namespace Hackathon2020.Poc01.Lib.Seeder
 {
     public class DataSeeder
     {
         IEdmModel model;
-        DbContext context;
+        IDataStore context;
         IEnumerable<TypeInfo> types;
 
-        public DataSeeder(IEdmModel model, DbContext context, IEnumerable<TypeInfo> types)
+        public DataSeeder(IEdmModel model, IDataStore context, IEnumerable<TypeInfo> types)
         {
             this.model = model;
             this.context = context;
@@ -27,6 +29,11 @@ namespace Hackathon2020.Poc01.Lib.Seeder
             foreach (var entitySet in model.EntityContainer.EntitySets())
             {
                 SeedEntitySet(entitySet);
+            }
+
+            foreach (var entitySet in model.EntityContainer.EntitySets())
+            {
+                AssignNavigationPropertiesFor(entitySet);
             }
 
             await context.SaveChangesAsync();
@@ -41,13 +48,112 @@ namespace Hackathon2020.Poc01.Lib.Seeder
             var addMethod = dbSet.GetType().GetMethod("Add");
             var generator = GetGeneratorForType(entityType);
 
-            int count = 100;
+            int count = 20;
+
+            var generatedKeys = new HashSet<object>();
 
             for (int i = 0; i < count; i++)
             {
-                var obj = generator.Invoke(null, new object[] { });
+                var obj = GenerateValue(generator);
+                AssignUniqueKey(obj, entityType, edmEntityType, generatedKeys);
                 addMethod.Invoke(dbSet, new[] { obj });
             }
+        }
+
+        private void AssignNavigationPropertiesFor(IEdmEntitySet entitySet)
+        {
+            var edmEntityType = entitySet.EntityType();
+            var entityType = GetEntityType(edmEntityType.Name);
+            var dbSet = GetDataSet(entityType);
+            var enumerable = dbSet as IEnumerable;
+            
+
+            //foreach (var edmNavProp in edmEntityType.DeclaredNavigationProperties())
+            //{
+            //    Console.WriteLine(edmNavProp.Name);
+            //}
+            foreach (var entity in enumerable)
+            {
+                foreach (var navProp in edmEntityType.NavigationProperties())
+                {
+                    if (navProp.ContainsTarget) continue;
+
+                    var isCollection = navProp.Type.IsCollection();
+
+                    if (isCollection)
+                    {
+                        AssignCollectionNavigationPropertyForEntity(entity, entityType, navProp);
+                    }
+                    else
+                    {
+                        AssignSingleNavigationPropertyForEntity(entity, entityType, navProp);
+                    }
+                }
+            }
+
+            
+        }
+
+        private void AssignSingleNavigationPropertyForEntity(object entity, Type entityType, IEdmNavigationProperty navProp)
+        {
+            var prop = entityType.GetProperty(navProp.Name.Split('/').Last());
+            prop.SetValue(entity, null);
+            var targetDbSet = GetDataSet(prop.PropertyType) as IEnumerable;
+            prop.SetValue(entity, GetRandomItem(targetDbSet));
+        }
+
+        private void AssignCollectionNavigationPropertyForEntity(object entity, Type entityType, IEdmNavigationProperty navProp)
+        {
+            var prop = entityType.GetProperty(navProp.Name.Split('/').Last());
+            var list = prop.GetValue(entity);
+            var clearMethod = prop.PropertyType.GetMethod("Clear");
+            clearMethod.Invoke(list, Array.Empty<object>());
+
+            var addMethod = prop.PropertyType.GetMethod("Add");
+
+            var targetDbSet = GetDataSet(prop.PropertyType.GetGenericArguments()[0]) as IEnumerable;
+            int maxItems = 10;
+            int addedCount = 0;
+
+            var random = new Random();
+
+            foreach (var item in targetDbSet)
+            {
+                if (random.Next(0, 10) < 3) // 0.3 chance of adding an item
+                {
+                    addMethod.Invoke(list, new[] { item });
+                    ++addedCount;
+
+                    if (addedCount == maxItems)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        private object GetRandomItem(IEnumerable dataSet)
+        {
+            var random = new Random();
+            var index = random.Next(0, 100);
+            int i = 0;
+            foreach (var item  in dataSet)
+            {
+                if (i == index) return item;
+                ++i;
+            }
+
+            return null;
+        }
+
+        private object GetDataSet(Type entityType)
+        {
+            return context.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(context, Array.Empty<object>());
+        }
+
+        private Type GetEntityType(string name)
+        {
+            return types.First(t => t.Name == name);
         }
 
         private MethodInfo GetGeneratorForType(Type type)
@@ -56,6 +162,34 @@ namespace Hackathon2020.Poc01.Lib.Seeder
             var generatMethod = typeof(AutoFaker).GetMethod("Generate", new[] { argType });
             var generateType = generatMethod.MakeGenericMethod(type);
             return generateType;
+        }
+
+        private object GenerateValue(MethodInfo generator)
+        {
+            return generator.Invoke(null, new object[] { null });
+        }
+
+        private object GenerateUniqueValue(Type type, ISet<object> existingKeys)
+        {
+            var generator = GetGeneratorForType(type);
+            var value = GenerateValue(generator);
+            while (existingKeys.Contains(value))
+            {
+                value = GenerateValue(generator);
+            }
+
+            existingKeys.Add(value);
+            return value;
+        }
+
+        private void AssignUniqueKey(object obj, Type entityType, IEdmEntityType edmEntityType, ISet<object> existingKeys)
+        {
+            // We only assign unique key for the first key property.
+            // Even if it's a composite key, if one of its values is unique, then the entire key is unique
+            var keyPropName = edmEntityType.Key().First().Name;
+            var prop = entityType.GetProperty(keyPropName);
+            var value = GenerateUniqueValue(prop.PropertyType, existingKeys);
+            prop.SetValue(obj, value);
         }
     }
 }

--- a/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
+++ b/Hackathon2020.Poc01/Lib/Seeder/DataSeeder.cs
@@ -15,13 +15,13 @@ namespace Hackathon2020.Poc01.Lib.Seeder
     public class DataSeeder
     {
         IEdmModel model;
-        IDataStore context;
+        IDataStore dataStore;
         IEnumerable<TypeInfo> types;
 
-        public DataSeeder(IEdmModel model, IDataStore context, IEnumerable<TypeInfo> types)
+        public DataSeeder(IEdmModel model, IDataStore dataStore, IEnumerable<TypeInfo> types)
         {
             this.model = model;
-            this.context = context;
+            this.dataStore = dataStore;
             this.types = types;
         }
         public async Task SeedData()
@@ -36,7 +36,7 @@ namespace Hackathon2020.Poc01.Lib.Seeder
                 AssignNavigationPropertiesFor(entitySet);
             }
 
-            await context.SaveChangesAsync();
+            await dataStore.SaveChangesAsync();
         }
 
         private void SeedEntitySet(IEdmEntitySet entitySet)
@@ -44,7 +44,7 @@ namespace Hackathon2020.Poc01.Lib.Seeder
             var edmEntityType = entitySet.EntityType();
             var entityType = types.First(t => t.Name == edmEntityType.Name);
 
-            var dbSet = context.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(context, Array.Empty<object>());
+            var dbSet = dataStore.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(dataStore, Array.Empty<object>());
             var addMethod = dbSet.GetType().GetMethod("Add");
             var generator = GetGeneratorForType(entityType);
 
@@ -148,7 +148,7 @@ namespace Hackathon2020.Poc01.Lib.Seeder
 
         private object GetDataSet(Type entityType)
         {
-            return context.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(context, Array.Empty<object>());
+            return dataStore.GetType().GetMethod("Set").MakeGenericMethod(entityType).Invoke(dataStore, Array.Empty<object>());
         }
 
         private Type GetEntityType(string name)

--- a/Hackathon2020.Poc01/ProjectEnv.cs
+++ b/Hackathon2020.Poc01/ProjectEnv.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Hackathon2020.Poc01
+{
+    public static class ProjectEnv
+    {
+        public static bool IsRemoveEnv()
+        {
+            return Environment.GetEnvironmentVariable("IS_REMOTE_ENV") == "true";
+        }
+
+        public static bool ShouldSeedData()
+        {
+            return Environment.GetEnvironmentVariable("SEED_DATA") == "true"
+                || Environment.GetCommandLineArgs().Contains("--seed_data")
+                || Environment.GetCommandLineArgs().Contains("-seed_data");
+        }
+    }
+}

--- a/Hackathon2020.Poc01/Startup.cs
+++ b/Hackathon2020.Poc01/Startup.cs
@@ -22,6 +22,8 @@ using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.OData.Routing.Conventions;
 using Azure.Storage.Files.Shares;
+using Hackathon2020.Poc01.Lib.Seeder;
+using DataLib;
 
 namespace Hackathon2020.Poc01
 {
@@ -58,19 +60,25 @@ namespace Hackathon2020.Poc01
             var optionsBuilder = new DbContextOptionsBuilder();
             var dbContextOptions = optionsBuilder.UseInMemoryDatabase("RapidApiDB").Options;
 
-            DbContext dbContext = (DbContext)Activator.CreateInstance(contextType, new object[] { dbContextOptions });
-         
+            //DbContext dbContext = (DbContext)Activator.CreateInstance(contextType, new object[] { dbContextOptions });
+            ListDataStore dbContext = (ListDataStore)Activator.CreateInstance(contextType);
+
+            var model = Model.GetModel();
+            Assembly targetAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name.Contains(DbContextConstants.Name));
+            var targetTypes = targetAssembly.DefinedTypes;
             //dbContext.Database.CreateIfNotExists();
+            var dataSeeder = new DataSeeder(model, dbContext, targetTypes);
+            dataSeeder.SeedData().Wait();
 
             services.AddSingleton(this.Configuration);
-            services.AddSingleton(typeof(DbContext), dbContext);
+            services.AddSingleton(typeof(IDataStore), dbContext);
 
             services.AddMvc(options => {
                     options.EnableEndpointRouting = false;
-                    options.Conventions.Insert(0, new DynamicControllerModelConvention(Model.GetModel()));
+                    options.Conventions.Insert(0, new DynamicControllerModelConvention(model));
                 })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
-                .ConfigureApplicationPartManager(d =>  d.FeatureProviders.Add(new DynamicControllerFeatureProvider(Model.GetModel())));
+                .ConfigureApplicationPartManager(d =>  d.FeatureProviders.Add(new DynamicControllerFeatureProvider(model)));
             services.AddControllers();
             services.AddOData();
         }

--- a/Hackathon2020.Poc01/Startup.cs
+++ b/Hackathon2020.Poc01/Startup.cs
@@ -61,7 +61,7 @@ namespace Hackathon2020.Poc01
             var dbContextOptions = optionsBuilder.UseInMemoryDatabase("RapidApiDB").Options;
 
             //DbContext dbContext = (DbContext)Activator.CreateInstance(contextType, new object[] { dbContextOptions });
-            ListDataStore dbContext = (ListDataStore)Activator.CreateInstance(contextType);
+            IDataStore dataStore = (IDataStore)Activator.CreateInstance(contextType);
 
             var model = Model.GetModel();
             Assembly targetAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name.Contains(DbContextConstants.Name));
@@ -70,12 +70,12 @@ namespace Hackathon2020.Poc01
 
             if (ProjectEnv.ShouldSeedData())
             {
-                var dataSeeder = new DataSeeder(model, dbContext, targetTypes);
+                var dataSeeder = new DataSeeder(model, dataStore, targetTypes);
                 dataSeeder.SeedData().Wait();
             }
 
             services.AddSingleton(this.Configuration);
-            services.AddSingleton(typeof(IDataStore), dbContext);
+            services.AddSingleton(typeof(IDataStore), dataStore);
 
             services.AddMvc(options => {
                     options.EnableEndpointRouting = false;

--- a/Hackathon2020.Poc01/Startup.cs
+++ b/Hackathon2020.Poc01/Startup.cs
@@ -38,7 +38,7 @@ namespace Hackathon2020.Poc01
 
         public void ConfigureServices(IServiceCollection services)
         {
-            if (Environment.GetEnvironmentVariable("IS_REMOTE_ENV") == "true")
+            if (ProjectEnv.IsRemoveEnv())
             {
                 var azureStorageConnString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
                 var azureFileShareName = Environment.GetEnvironmentVariable("AZURE_FILE_SHARE_NAME");
@@ -67,8 +67,12 @@ namespace Hackathon2020.Poc01
             Assembly targetAssembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name.Contains(DbContextConstants.Name));
             var targetTypes = targetAssembly.DefinedTypes;
             //dbContext.Database.CreateIfNotExists();
-            var dataSeeder = new DataSeeder(model, dbContext, targetTypes);
-            dataSeeder.SeedData().Wait();
+
+            if (ProjectEnv.ShouldSeedData())
+            {
+                var dataSeeder = new DataSeeder(model, dbContext, targetTypes);
+                dataSeeder.SeedData().Wait();
+            }
 
             services.AddSingleton(this.Configuration);
             services.AddSingleton(typeof(IDataStore), dbContext);

--- a/Hackathon2020.Poc01/project.csdl
+++ b/Hackathon2020.Poc01/project.csdl
@@ -49,7 +49,7 @@
         </Property>
         <Property Name="FirstName" Type="Edm.String" Nullable="false" />
         <Property Name="LastName" Type="Edm.String" Nullable="false" />
-        <!--<Property Name="Emails" Type="Collection(Edm.String)" />-->
+        <Property Name="Emails" Type="Collection(Edm.String)" />
         <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
         <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
         <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
@@ -130,7 +130,7 @@
         </Property>
         <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
         <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
-        <!--<Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />-->
+        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
         <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
         <NavigationProperty Name="PlanItems" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)" ContainsTarget="true" />
       </EntityType>


### PR DESCRIPTION
- Seeds dummy data to database when `--seed_data` command line arg or `SEED_DATA=true` env variable are set
- Migrates data store from EF-Core to a `List` based data store to avoid complexities of configuring complex schemas in EF Core